### PR TITLE
Update elFinderVolumeS3.class.php for s3 support

### DIFF
--- a/src/elFinder/elFinderVolumeS3.class.php
+++ b/src/elFinder/elFinderVolumeS3.class.php
@@ -582,7 +582,7 @@ class elFinderVolumeS3 extends elFinderVolumeDriver {
 	 * @return bool|string
 	 * @author Dmitry (dio) Levashov
 	 **/
-	protected function _save($fp, $dir, $name, $mime, $w, $h) {
+	protected function _save($fp, $dir, $name, $stat) {
 		return false;
 	}
 	


### PR DESCRIPTION
This should resolve this exception: 

Symfony \ Component \ Debug \ Exception \ FatalErrorException
Declaration of elFinderVolumeS3::_save() must be compatible with elFinderVolumeDriver::_save($fp, $dir, $name, $stat)
