### PR TITLE
fix send file url to ckeditor

### DIFF
--- a/src/views/ckeditor4.php
+++ b/src/views/ckeditor4.php
@@ -23,10 +23,24 @@
 
     <!-- elFinder initialization (REQUIRED) -->
     <script type="text/javascript" charset="utf-8">
+        // Helper function to get parameters from the query string.
+        function getUrlParam(paramName) {
+            var reParam = new RegExp('(?:[\?&]|&amp;)' + paramName + '=([^&]+)', 'i') ;
+            var match = window.location.search.match(reParam) ;
+
+            return (match && match.length > 1) ? match[1] : '' ;
+        }
+
         $().ready(function() {
+            var funcNum = getUrlParam('CKEditorFuncNum');
+
             var elf = $('#elfinder').elfinder({
-                <?php if($locale){ echo "lang: '$locale',\n"; } ?>
-                url: '<?= URL::action('Barryvdh\Elfinder\ElfinderController@showConnector') ?>',  // connector URL
+                url : 'php/connector.php',
+                getFileCallback : function(file) {
+                    window.opener.CKEDITOR.tools.callFunction(funcNum, file);
+                    window.close();
+                },
+                resizable: false
             }).elfinder('instance');
         });
     </script>
@@ -35,28 +49,7 @@
 
 <!-- Element where elFinder will be created (REQUIRED) -->
 <div id="elfinder"></div>
-<script type="text/javascript" charset="utf-8">
-    // Helper function to get parameters from the query string.
-    function getUrlParam(paramName) {
-        var reParam = new RegExp('(?:[\?&]|&amp;)' + paramName + '=([^&]+)', 'i') ;
-        var match = window.location.search.match(reParam) ;
 
-        return (match && match.length > 1) ? match[1] : '' ;
-    }
-
-    $().ready(function() {
-        var funcNum = getUrlParam('CKEditorFuncNum');
-
-        var elf = $('#elfinder').elfinder({
-            url : 'php/connector.php',
-            getFileCallback : function(file) {
-                window.opener.CKEDITOR.tools.callFunction(funcNum, file);
-                window.close();
-            },
-            resizable: false
-        }).elfinder('instance');
-    });
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
CKeditor does not work correctly.  If you double click on an image in elfinder, it opens it instead of adding it to ckeditor.

Easy fix... in ckeditor4.php basically replace :

```
<script type="text/javascript" charset="utf-8">
    $().ready(function() {
        var elf = $('#elfinder').elfinder({
            <?php if($locale){ echo "lang: '$locale',\n"; } ?>
            url: '<?= URL::action('Barryvdh\Elfinder\ElfinderController@showConnector') ?>',  // connector URL
        }).elfinder('instance');
    });
</script>
```

with:

```
<script type="text/javascript" charset="utf-8">
    // Helper function to get parameters from the query string.
    function getUrlParam(paramName) {
        var reParam = new RegExp('(?:[\?&]|&amp;)' + paramName + '=([^&]+)', 'i') ;
        var match = window.location.search.match(reParam) ;

        return (match && match.length > 1) ? match[1] : '' ;
    }

    $().ready(function() {
        var funcNum = getUrlParam('CKEditorFuncNum');

        var elf = $('#elfinder').elfinder({
            url : 'php/connector.php',
            getFileCallback : function(file) {
                window.opener.CKEDITOR.tools.callFunction(funcNum, file);
                window.close();
            },
            resizable: false
        }).elfinder('instance');
    });
</script>
```
