### PR TITLE
Use Controller instead of BaseController

### DIFF
--- a/src/Barryvdh/Elfinder/ElfinderController.php
+++ b/src/Barryvdh/Elfinder/ElfinderController.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Elfinder;
 use Config;
 use View;
 
-class ElfinderController extends \BaseController
+class ElfinderController extends \Controller
 {
     protected $package = 'laravel-elfinder';
 


### PR DESCRIPTION
I use `BaseController` in a namespace.
