### PR TITLE
Change default asset path to match published destination.

### DIFF
--- a/src/ElfinderServiceProvider.php
+++ b/src/ElfinderServiceProvider.php
@@ -59,7 +59,7 @@ class ElfinderServiceProvider extends RouteServiceProvider {
         ], 'views');
 
         if (!defined('ELFINDER_IMG_PARENT_URL')) {
-			define('ELFINDER_IMG_PARENT_URL', $this->app['url']->asset('packages/barryvdh/laravel-elfinder'));
+			define('ELFINDER_IMG_PARENT_URL', $this->app['url']->asset('packages/barryvdh/elfinder'));
 		}
 	}
 


### PR DESCRIPTION
The volume_icon_local.png image wasn't loading in elfinder because it was looking for the image in:
/public/packages/barryvdh/laravel-elfinder/img

instead of where it gets published to:
/public/packages/barryvdh/elfinder/img