### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Files are updated from the a seperate [build repository](https://github.com/barr
 
 Require this package with Composer
     
-    composer require barryvdh/laravel-elfinder
+    composer require barryvdh/laravel-elfinder 0.2
     
 Add the ServiceProvider to the providers array in app/config/app.php
 


### PR DESCRIPTION
Readme.md seems to mirror the L5 version. Users installing to L4 will receive errors suggesting they need to uninstall L4.\* and install L5+.
Adding the branch to the require declaration fixes this issue and allows the dependency to be installed.

Pre-Change:

```
 vagrant@homestead:~/sole/Code/Laravel$ composer require barryvdh/laravel-elfinder
Using version ^0.3.4 for barryvdh/laravel-elfinder
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
- Installation request for barryvdh/laravel-elfinder ^0.3.4 -> satisfiable by barryvdh/laravel-elfinder[v0.3.4].
- Conclusion: remove laravel/framework v4.2.17
- Conclusion: don't install laravel/framework v4.2.17
- barryvdh/laravel-elfinder v0.3.4 requires illuminate/support 5.0.x|5.1.x -> satisfiable by illuminate/support[v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.28, v5.0.33, v5.0.4, v5.1.1, v5.1.2].
Installation failed, reverting ./composer.json to its original content.
```

Post-Change:

```
vagrant@homestead:~/sole/Code/Laravel$ composer require barryvdh/laravel-elfinder 0.2
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing barryvdh/elfinder-builds (v2.1.0.3)
    Downloading: 100%         

  - Installing barryvdh/laravel-elfinder (v0.2.0)
    Downloading: 100%         

Writing lock file
Generating autoload files
Generating optimized class loader
```
