### PR TITLE
Add flysystem disks with laravel 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "barryvdh/elfinder-builds": "2.1.x"
+        "barryvdh/elfinder-builds": "2.1.x",
+        "barryvdh/elfinder-flysystem-driver": "0.1.x@dev"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,23 @@ The default configuration requires a directory called 'files' in the public fold
 
 In your app/config/packages/barryvdh/laravel-elfinder, you can change the default folder, the access callback or define your own roots.
 
+### Using Filesystem disks
+
+Laravel 4 has the ability to use Flysystem adapters using the package "graham-campbell/flysystem": "~1.0" [found here](https://github.com/GrahamCampbell/Laravel-Flysystem/tree/v1.0.0) as local/cloud disks. You can add those disks to elFinder, using the `disks` config.
+
+This examples adds the `local` disk and `my-disk`:
+
+    'disks' => [
+        'local',
+        'my-disk' => [
+            'URL' => url('to/disk'),
+            'alias' => 'Local storage',
+        ]
+    ],
+    
+You can add an array to provide extra options, like the URL, alias etc. [Look here](https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options-2.1#root-options) for all options.
+Also see [elfinder-flysystem-driver](https://github.com/barryvdh/elfinder-flysystem-driver) for [Glide](http://glide.thephpleague.com/) usage. 
+
 ### TinyMCE 4.x
 
 You can add tinyMCE integration by adding the following route:

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -10,8 +10,24 @@ return array(
     | The dir where to store the images (relative from public)
     |
     */
+    'dir' => ['files'],
 
-    'dir' => 'files',
+    /*
+    |--------------------------------------------------------------------------
+    | Filesystem disks (Flysytem)
+    |--------------------------------------------------------------------------
+    |
+    | Define an array of Filesystem disks, which use Flysystem.
+    | You can set extra options, example:
+    |
+    | 'my-disk' => [
+    |        'URL' => url('to/disk'),
+    |        'alias' => 'Local storage',
+    |    ]
+    */
+    'disks' => [
+
+    ],
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This brings the new disk feature to the Laravel 4 branch with use of https://github.com/GrahamCampbell/Laravel-Flysystem
to provide the "filesystem" that laravel-elfinder expects for disks and so all disk config can be found in one place.