### PR TITLE
[Fix] Replacing 'file_browser_callback' (deprecated) with 'file_picker_callback'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,28 +112,29 @@ You can use tinyMCE integration with the following route, which by default is `/
 In the TinyMCE init code, add the following line:
 
 ```javascript
-file_browser_callback : elFinderBrowser
+file_picker_callback : elFinderBrowser
 ```
 
 Then add the following function (change the `elfinder_url` to the correct path on your system):
 
 ```javascript
-function elFinderBrowser (field_name, url, type, win) {
-  tinymce.activeEditor.windowManager.open({
-    file: '<?= route('elfinder.tinymce4') ?>',// use an absolute path!
-    title: 'elFinder 2.0',
-    width: 900,
-    height: 450,
-    resizable: 'yes'
-  }, {
-    setUrl: function (url) {
-      win.document.getElementById(field_name).value = url;
-    }
-  });
-  return false;
+function elFinderBrowser(callback, value, meta) {
+    var request = "{{ action('\Barryvdh\Elfinder\ElfinderController@showTinyMCE4') }}";
+    tinymce.activeEditor.windowManager.open({
+        title: 'File Manager',
+        url: request,
+        width: 900,
+        height: 550,
+    }, {
+        oninsert: function (url) {
+            callback(url);
+        }
+    });
+    
+    return false;
 }
 ```
- 
+
 ### TinyMCE 3.x
 
 You can add tinyMCE integration with the following route (default: `/elfinder/tinymce`):

--- a/resources/views/tinymce4.php
+++ b/resources/views/tinymce4.php
@@ -29,7 +29,7 @@
             },
             mySubmit: function (URL) {
                 // pass selected file path to TinyMCE
-                parent.tinymce.activeEditor.windowManager.getParams().setUrl(URL);
+                parent.tinymce.activeEditor.windowManager.getParams().oninsert(URL);
 
                 // close popup window
                 parent.tinymce.activeEditor.windowManager.close();


### PR DESCRIPTION
Updated views and readme as 'file_browser_callback' have been replaced with 'file_picker_callback' as per version [4.2.1](http://www.tinymce.com/develop/bugtracker_view.php?id=7585). 

Signed-off-by: Kevin Sanderson novusperdiem@gmail.com
