### PR TITLE
Fix for hifenized locales;

### DIFF
--- a/resources/views/filepicker.php
+++ b/resources/views/filepicker.php
@@ -35,7 +35,7 @@
                 url: '<?= route("elfinder.connector") ?>',  // connector URL
                 resizable: false,
                 ui: ['toolbar', 'path','stat'],
-                onlyMimes: ["image"],
+                onlyMimes: ["{!!type!!}"],
                 rememberLastDir : false,
                 height: 300,
                 defaultView: 'list',

--- a/resources/views/filepicker.php
+++ b/resources/views/filepicker.php
@@ -23,7 +23,7 @@
     <!-- Include jQuery, jQuery UI, elFinder (REQUIRED) -->
 
     <?php
-    $mimeTypes = $mimeTypes = implode(',',array_map(function($t){return "'".$t."'";}, explode(',',$type)));
+    $mimeTypes = implode(',',array_map(function($t){return "'".$t."'";}, explode(',',$type)));
     ?>
 
     <script type="text/javascript">
@@ -33,7 +33,7 @@
                 <?php if($locale){ ?>
                     lang: '<?= $locale ?>', // locale
                 <?php } ?>
-                customData: { 
+                customData: {
                     _token: '<?= csrf_token() ?>'
                 },
                 url: '<?= route("elfinder.connector") ?>',  // connector URL
@@ -47,7 +47,7 @@
                     window.parent.processSelectedFile(file, '<?= $input_id?>');
                     console.log(file);
                 },
-                
+
                 uiOptions : {
                     // toolbar configuration
                     toolbar : [

--- a/resources/views/filepicker.php
+++ b/resources/views/filepicker.php
@@ -22,6 +22,10 @@
     <?php } ?>
     <!-- Include jQuery, jQuery UI, elFinder (REQUIRED) -->
 
+    <?php
+    $mimeTypes = $mimeTypes = implode(',',array_map(function($t){return "'".$t."'";}, explode(',',$type)));
+    ?>
+
     <script type="text/javascript">
         $().ready(function () {
             var elf = $('#elfinder').elfinder({
@@ -35,7 +39,7 @@
                 url: '<?= route("elfinder.connector") ?>',  // connector URL
                 resizable: false,
                 ui: ['toolbar', 'path','stat'],
-                onlyMimes: ["{!!type!!}"],
+                onlyMimes: [<?= $mimeTypes ?>],
                 rememberLastDir : false,
                 height: 300,
                 defaultView: 'list',

--- a/resources/views/imgpicker.php
+++ b/resources/views/imgpicker.php
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>elFinder 2.0</title>
+
+    <!-- jQuery and jQuery UI (REQUIRED) -->
+    <link rel="stylesheet" type="text/css" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/themes/smoothness/jquery-ui.css">
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+
+    <!-- elFinder CSS (REQUIRED) -->
+    <link rel="stylesheet" type="text/css" href="<?= asset($dir . '/css/elfinder.min.css') ?>">
+    <link rel="stylesheet" type="text/css" href="<?= asset($dir . '/css/theme.css') ?>">
+
+    <!-- elFinder JS (REQUIRED) -->
+    <script src="<?= asset($dir . '/js/elfinder.min.js') ?>"></script>
+
+    <?php if ($locale) { ?>
+        <!-- elFinder translation (OPTIONAL) -->
+        <script src="<?= asset($dir . "/js/i18n/elfinder.$locale.js") ?>"></script>
+    <?php } ?>
+    <!-- Include jQuery, jQuery UI, elFinder (REQUIRED) -->
+
+    <script type="text/javascript">
+        $().ready(function () {
+            var elf = $('#elfinder').elfinder({
+                // set your elFinder options here
+                <?php if($locale){ ?>
+                    lang: '<?= $locale ?>', // locale
+                <?php } ?>
+                customData: { 
+                    _token: '<?= csrf_token() ?>'
+                },
+                url: '<?= route("elfinder.connector") ?>',  // connector URL
+                resizable: false,
+                ui: ['toolbar', 'path','stat'],
+                onlyMimes: ["image"],
+                rememberLastDir : false,
+                height: 300,
+                defaultView: 'list',
+                getFileCallback: function (file) {
+                    window.parent.processSelectedFile(file, '<?= $input_id?>');
+                    console.log(file);
+                },
+                
+                uiOptions : {
+                    // toolbar configuration
+                    toolbar : [
+                        ['home', 'up'],
+                        ['upload'],
+
+                        ['quicklook'],
+
+                    ],
+                    // directories tree options
+                    tree : {
+                        // expand current root on init
+                        openRootOnLoad : true,
+                        // auto load current dir parents
+                        syncTree : true
+                    },
+                    // navbar options
+                    navbar : {
+                        minWidth : 150,
+                        maxWidth : 500
+                    },
+
+                    // current working directory options
+                    cwd : {
+                        // display parent directory in listing as ".."
+                        oldSchool : false
+                    }
+                }
+            }).elfinder('instance');
+        });
+    </script>
+
+
+</head>
+<body style="margin: 0;">
+<!-- Element where elFinder will be created (REQUIRED) -->
+<div id="elfinder"></div>
+
+</body>
+</html>

--- a/src/ElfinderController.php
+++ b/src/ElfinderController.php
@@ -56,12 +56,12 @@ class ElfinderController extends Controller
             ->with(compact('input_id'));
     }
 
-    public function showImagePicker($input_id)
+    public function showFilePicker($input_id, $type = '')
     {
         return $this->app['view']
-            ->make($this->package . '::imgpicker')
+            ->make($this->package . '::filepicker')
             ->with($this->getViewVars())
-            ->with(compact('input_id'));
+            ->with(compact('input_id','type'));
     }
 
     public function showConnector()

--- a/src/ElfinderController.php
+++ b/src/ElfinderController.php
@@ -1,8 +1,9 @@
 <?php namespace Barryvdh\Elfinder;
 
-use Illuminate\Routing\Controller;
-use Illuminate\Foundation\Application;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Request;
 
 class ElfinderController extends Controller
 {
@@ -56,8 +57,9 @@ class ElfinderController extends Controller
             ->with(compact('input_id'));
     }
 
-    public function showFilePicker($input_id, $type = '')
+    public function showFilePicker($input_id)
     {
+        $type = Request::input('type');
         return $this->app['view']
             ->make($this->package . '::filepicker')
             ->with($this->getViewVars())

--- a/src/ElfinderController.php
+++ b/src/ElfinderController.php
@@ -100,7 +100,7 @@ class ElfinderController extends Controller
     protected function getViewVars()
     {
         $dir = 'packages/barryvdh/' . $this->package;
-        $locale = $this->app->config->get('app.locale');
+        $locale = str_replace("-",  "_", $this->app->config->get('app.locale'));
         if (!file_exists($this->app['path.public'] . "/$dir/js/i18n/elfinder.$locale.js")) {
             $locale = false;
         }

--- a/src/ElfinderController.php
+++ b/src/ElfinderController.php
@@ -19,7 +19,7 @@ class ElfinderController extends Controller
     {
         $this->app = $app;
     }
-        
+
     public function showIndex()
     {
         return $this->app['view']
@@ -52,6 +52,14 @@ class ElfinderController extends Controller
     {
         return $this->app['view']
             ->make($this->package . '::standalonepopup')
+            ->with($this->getViewVars())
+            ->with(compact('input_id'));
+    }
+
+    public function showImagePicker($input_id)
+    {
+        return $this->app['view']
+            ->make($this->package . '::imgpicker')
             ->with($this->getViewVars())
             ->with(compact('input_id'));
     }

--- a/src/ElfinderServiceProvider.php
+++ b/src/ElfinderServiceProvider.php
@@ -57,7 +57,7 @@ class ElfinderServiceProvider extends ServiceProvider {
             $router->get('/', 'ElfinderController@showIndex');
             $router->any('connector', ['as' => 'elfinder.connector', 'uses' => 'ElfinderController@showConnector']);
             $router->get('popup/{input_id}', ['as' => 'elfinder.popup', 'uses' => 'ElfinderController@showPopup']);
-            $router->get('imgpicker/{input_id}', ['as' => 'elfinder.imgpicker', 'uses' => 'ElfinderController@showImagePicker']);
+            $router->get('filepicker/{input_id}', ['as' => 'elfinder.filepicker', 'uses' => 'ElfinderController@showFilePicker']);
             $router->get('tinymce', ['as' => 'elfinder.tinymce', 'uses' => 'ElfinderController@showTinyMCE']);
             $router->get('tinymce4', ['as' => 'elfinder.tinymce4', 'uses' => 'ElfinderController@showTinyMCE4']);
             $router->get('ckeditor', ['as' => 'elfinder.ckeditor', 'uses' => 'ElfinderController@showCKeditor4']);

--- a/src/ElfinderServiceProvider.php
+++ b/src/ElfinderServiceProvider.php
@@ -30,7 +30,7 @@ class ElfinderServiceProvider extends ServiceProvider {
         });
         $this->commands('command.elfinder.publish');
 	}
-    
+
 	/**
 	 * Define your route model bindings, pattern filters, etc.
 	 *
@@ -57,6 +57,7 @@ class ElfinderServiceProvider extends ServiceProvider {
             $router->get('/', 'ElfinderController@showIndex');
             $router->any('connector', ['as' => 'elfinder.connector', 'uses' => 'ElfinderController@showConnector']);
             $router->get('popup/{input_id}', ['as' => 'elfinder.popup', 'uses' => 'ElfinderController@showPopup']);
+            $router->get('imgpicker/{input_id}', ['as' => 'elfinder.imgpicker', 'uses' => 'ElfinderController@showImagePicker']);
             $router->get('tinymce', ['as' => 'elfinder.tinymce', 'uses' => 'ElfinderController@showTinyMCE']);
             $router->get('tinymce4', ['as' => 'elfinder.tinymce4', 'uses' => 'ElfinderController@showTinyMCE4']);
             $router->get('ckeditor', ['as' => 'elfinder.ckeditor', 'uses' => 'ElfinderController@showCKeditor4']);


### PR DESCRIPTION
Locales in PHP come with hifens (e.g. `pt-BR`), while the elfinder js library uses underscores (e.g. `pt_BR`). This is  a simple fix for those situations.