### PR TITLE
Trigger change event for libraries like VueJS.

### DIFF
--- a/resources/assets/js/standalonepopup.js
+++ b/resources/assets/js/standalonepopup.js
@@ -16,5 +16,5 @@ $(document).on('click','.popup_selector',function (event) {
 });
 // function to update the file selected by elfinder
 function processSelectedFile(filePath, requestingField) {
-    $('#' + requestingField).val(filePath);
+    $('#' + requestingField).val(filePath).trigger('change');
 }


### PR DESCRIPTION
Elfinder only change the value, libraries like VueJS won't see this as a change. VueJS models will not be updated without triggering this event.