### PR TITLE
Fix rewind(): stream does not support seeking error

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -45,7 +45,9 @@ class Connector extends \elFinderConnector {
 
         if (isset($data['pointer'])) {
             $this->response = new StreamedResponse(function () use($data) {
-                    rewind($data['pointer']);
+                    if (stream_get_meta_data($data['pointer'])['seekable']) {
+                        rewind($data['pointer']);
+                    }
                     fpassthru($data['pointer']);
                     if (!empty($data['volume'])) {
                         $data['volume']->close($data['pointer'], $data['info']['hash']);


### PR DESCRIPTION
This fixes an error when trying to download files via laravel-elfinder from a flysystem volume using a remote storage solution (I am getting this error with an S3 volume).

#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'rewind(): stream does not support seeking', '/var/www/v...', 48, Array)
#1 /var/www/visionair/fbo/vendor/barryvdh/laravel-elfinder/src/Connector.php(48): rewind(Resource id #23)
[...]