### PR TITLE
Added Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.x",
+        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x|5.5.x|5.6.x",
         "studio-42/elfinder": "~2.1.10",
         "barryvdh/elfinder-flysystem-driver": "^0.1.4|^0.2",
         "league/flysystem": "^1.0",


### PR DESCRIPTION
@barryvdh ,

This brings support for Laravel 5.6 (released ~12 hours ago). I've gone through the entire upgrade guide and tested the most important use cases of laravel-elfinder - works like a charm.

![screen recording 2018-02-08 at 09 24 am](https://user-images.githubusercontent.com/1032474/35960488-7c6f70f0-0cb2-11e8-8f24-b91a683352ff.gif)

Would be great if we had this merged and tagged (0.3.12).
Thanks!

PS. I don't think I've thanked you for laravel-elfinder yet - big BIG thanks, we make so much use of it, even in [Backpack for Laravel](https://backpackforlaravel.com/). Thank you for making all our lives easier!