### PR TITLE
Update readme.md. Remove single quotes or use double quotes.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ You can change the prefix or filter/middleware for the routes. If you want full 
 
 The default configuration requires a directory called 'files' in the public folder. You can change this by publishing the config file.
 
-    php artisan vendor:publish --provider='Barryvdh\Elfinder\ElfinderServiceProvider' --tag=config
+    php artisan vendor:publish --provider=Barryvdh\Elfinder\ElfinderServiceProvider --tag=config
 
 In your config/elfinder.php, you can change the default folder, the access callback or define your own roots.
 
@@ -45,7 +45,7 @@ In your config/elfinder.php, you can change the default folder, the access callb
 
 You can override the default views by copying the resources/views folder. You can also do that with the `vendor:publish` command:
 
-    php artisan vendor:publish --provider='Barryvdh\Elfinder\ElfinderServiceProvider' --tag=views
+    php artisan vendor:publish --provider=Barryvdh\Elfinder\ElfinderServiceProvider --tag=views
 
 ### Using Filesystem disks
 


### PR DESCRIPTION
https://github.com/barryvdh/laravel-elfinder/issues/217

This command does not work with laravel 5.5 or higher.
Remove single quotes or use double quotes.

`php artisan vendor:publish --provider=Barryvdh\Elfinder\ElfinderServiceProvider --tag=config`
or
`php artisan vendor:publish --provider="Barryvdh\Elfinder\ElfinderServiceProvider" --tag=config`

