### PR TITLE
Fix readme for section tinyMCE 5.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ route('elfinder.tinymce5');
 In the TinyMCE init code, add the following line:
 
 ```javascript
-file_picker_callback : elFinderBrowser
+file_browser_callback : elFinderBrowser
 ```
 
 Then add the following function (change the `elfinder_url` to the correct path on your system):

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ route('elfinder.tinymce5');
 In the TinyMCE init code, add the following line:
 
 ```javascript
-file_browser_callback : elFinderBrowser
+file_picker_callback : elFinderBrowser
 ```
 
 Then add the following function (change the `elfinder_url` to the correct path on your system):


### PR DESCRIPTION
This replaces the **file_browser_callback** (removed in version 5.0) option. The new **file_picker_callback** provides a way to update values of other fields in the dialog.
Address bellow
https://www.tiny.cloud/docs/configure/file-image-upload/#file_picker_callback