### PR TITLE
Set default disk.

### DIFF
--- a/config/elfinder.php
+++ b/config/elfinder.php
@@ -26,7 +26,7 @@ return array(
     |    ]
     */
     'disks' => [
-
+        'local',
     ],
 
     /*


### PR DESCRIPTION
Default to Laravel's default filesystem driver.

Just a convenience that a user doesn't have to set this first to get started.

Plus, the readme doesn't mention that setting a disk is mandatory.