### PR TITLE
add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.5|^6|^7",
+        "illuminate/support": "^5.5|^6|^7|^8",
         "studio-42/elfinder": "~2.1.49",
         "barryvdh/elfinder-flysystem-driver": "^0.2",
         "league/flysystem": "^1.0",


### PR DESCRIPTION
Good news @barryvdh ! it looks like all we need to do, to provide Laravel 8 support, is to allow the installation 🥳  I have tested the most important features, and they work just fine:

![2020-09-08 10 07 20](https://user-images.githubusercontent.com/1032474/92487465-42326a00-f1bb-11ea-9de4-e67aa7d72e86.gif)

---

If anybody else wants to test this, or upgrade to Laravel 8 before this PR gets merged (or an alternative one), please: 
- add my fork to your `composer.json`'s repositories section:
```json
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/tabacitu/laravel-elfinder"
        }
    ],
```
- run `composer require barryvdh/laravel-elfinder:"dev-l8-compatibility as 0.4.99"`

Note that I have no intention of keeping that fork. Immediately after the official repo provides Laravel 8 support, I'll delete it. At that point you should undo the changes above, run `composer update` and it'll work just fine.