### PR TITLE
jqueryui/1.10.4 to jqueryui/1.13.1

### DIFF
--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -5,9 +5,9 @@
         <title>elFinder 2.0</title>
 
         <!-- jQuery and jQuery UI (REQUIRED) -->
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/themes/smoothness/jquery-ui.css" />
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/jquery-ui.min.js"></script>
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/themes/smoothness/jquery-ui.css" />
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
 
         <!-- elFinder CSS (REQUIRED) -->
         <link rel="stylesheet" type="text/css" href="{{ asset($dir.'/css/elfinder.min.css') }}">

--- a/resources/views/elfinder.blade.php
+++ b/resources/views/elfinder.blade.php
@@ -5,9 +5,9 @@
         <title>elFinder 2.0</title>
 
         <!-- jQuery and jQuery UI (REQUIRED) -->
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/themes/smoothness/jquery-ui.css" />
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/jquery-ui.min.js"></script>
 
         <!-- elFinder CSS (REQUIRED) -->
         <link rel="stylesheet" type="text/css" href="{{ asset($dir.'/css/elfinder.min.css') }}">

--- a/resources/views/elfinder.php
+++ b/resources/views/elfinder.php
@@ -5,9 +5,9 @@
         <title>elFinder 2.0</title>
 
         <!-- jQuery and jQuery UI (REQUIRED) -->
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/themes/smoothness/jquery-ui.css" />
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/jquery-ui.min.js"></script>
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/themes/smoothness/jquery-ui.css" />
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
 
         <!-- elFinder CSS (REQUIRED) -->
         <link rel="stylesheet" type="text/css" href="<?= asset($dir.'/css/elfinder.min.css') ?>">

--- a/resources/views/elfinder.php
+++ b/resources/views/elfinder.php
@@ -5,9 +5,9 @@
         <title>elFinder 2.0</title>
 
         <!-- jQuery and jQuery UI (REQUIRED) -->
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css" />
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/themes/smoothness/jquery-ui.css" />
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.13.1/jquery-ui.min.js"></script>
 
         <!-- elFinder CSS (REQUIRED) -->
         <link rel="stylesheet" type="text/css" href="<?= asset($dir.'/css/elfinder.min.css') ?>">


### PR DESCRIPTION
jqueryui/1.10.4 to jqueryui/1.13.1

Because some of designs were breaking which solved in this new version and elFinder itself used this new jQueryUI.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

?? Some of designs were breaking ( https://prnt.sc/OtGVbr3V1Gnc )

### AFTER - What is happening after this PR?

?? This type of breaking are solved ( https://prnt.sc/ynytaD8uXQSu )


## HOW

### How did you achieve that, in technical terms?

?? Just changed from *jqueryui/1.10.4* to *jqueryui/1.13.1*



### Is it a breaking change or non-breaking change?

?? Yes, it was a large issue, without that we could not close or reopen (pop up) the area ever again!


### How can we test the before & after?

?? Just change the version in file `\resources\views\elfinder.blade.php` and `\resources\views\elfinder.php` 
