### PR TITLE
Update  2.1.62 Elfinder CVE Fixed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 [Next release]
 --------------
 
-2023-07-20 0.5.1
+
+2023-07-20, 0.5.3
+------------------
 
 - Update elfinder to 2.1.62 because CVE-2023-35840
 
@@ -17,7 +19,16 @@ All notable changes to this project will be documented in this file.
 | Reported at       | 2023-06-14T16:37:01+00:00
 
 
+2023-02-05, 0.5.2
+------------------
 
+Allow Laravel 10
+Laravel 10.x Compatibility (#321)
+
+* Bump dependencies for Laravel 10
+
+* Relax constraints
+ 
 
 2022-03-15, 0.5.0
 ------------------

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 [Next release]
 --------------
 
+2023-07-20 0.5.1
+
+- Update elfinder to 2.1.62 because CVE-2023-35840
+
+|                     studio-42/elfinder                                                               |
+| CVE               | CVE-2023-35840                                                                   |
+| Title             | elFinder vulnerable to path traversal in LocalVolumeDriver connector             |
+| URL               | https://github.com/advisories/GHSA-wm5g-p99q-66g4                                |
+| Affected versions | <2.1.62                                                                          |
+| Reported at       | 2023-06-14T16:37:01+00:00
+
+
+
+
 2022-03-15, 0.5.0
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^9|^10",
-        "studio-42/elfinder": "~2.1.49",
+        "studio-42/elfinder": "~2.1.62",
         "barryvdh/elfinder-flysystem-driver": "^0.4.2"
     },
     "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 [![Latest Stable Version](https://poser.pugx.org/barryvdh/laravel-elfinder/version.png)](https://packagist.org/packages/barryvdh/laravel-elfinder)
 [![Total Downloads](https://poser.pugx.org/barryvdh/laravel-elfinder/d/total.png)](https://packagist.org/packages/barryvdh/laravel-elfinder)
 
-This packages integrates [elFinder 2.1](https://github.com/Studio-42/elFinder/tree/2.1), 
+This packages integrates [elFinder 2.1.62](https://github.com/Studio-42/elFinder/tree/2.1.62), 
 by making the php files available with Composer (+autoloading) and the assets with a publish command. It also provides some example views for standalone, tinymce and ckeditor.
 Files are updated from the a seperate [build repository](https://github.com/barryvdh/elfinder-builds)
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 [![Latest Stable Version](https://poser.pugx.org/barryvdh/laravel-elfinder/version.png)](https://packagist.org/packages/barryvdh/laravel-elfinder)
 [![Total Downloads](https://poser.pugx.org/barryvdh/laravel-elfinder/d/total.png)](https://packagist.org/packages/barryvdh/laravel-elfinder)
 
-This packages integrates [elFinder 2.1.62](https://github.com/Studio-42/elFinder/tree/2.1.62), 
+This packages integrates [elFinder](https://github.com/Studio-42/elFinder), 
 by making the php files available with Composer (+autoloading) and the assets with a publish command. It also provides some example views for standalone, tinymce and ckeditor.
 Files are updated from the a seperate [build repository](https://github.com/barryvdh/elfinder-builds)
 


### PR DESCRIPTION
Because of the latest CVE-2023-35840  it will be necessary for everyone to update their versions